### PR TITLE
补充了遗漏的零声母音节 ei er 和 ao

### DIFF
--- a/scripts/flypy_dict_generator_new.py
+++ b/scripts/flypy_dict_generator_new.py
@@ -126,6 +126,9 @@ def pinyin_to_flypy(quanpin: list[str]):
             "n": "en",
             "en": "en",
             "eng": "eg",
+            "ei": "ei",
+            "er": "er",
+            "ao": "ao",
         }
         # 错误 Pinyin 返回原始拼音串
         if len(pinyin) == 1 and pinyin not in zero:


### PR DESCRIPTION
零声母音节共12个(https://flypy.cc/#/lu) 
代码中多了 n 到 en 的映射（保留未删）补充了缺失的三个

此前代码运行无问题是因为这一行的fall back：https://github.com/boomker/rime-fast-xhup/blob/efe42e802527760cb8cc2bc85c533016c7496246/scripts/flypy_dict_generator_new.py#L141
如 er 被拆成了声母为e 韵母以r查yunmu字典无结果, 仍为r —— 所以结果依然为er

虽然改动不影响结果 但零声母音节确实缺了3个 😃