### PR TITLE
fix f5m freeze on deploy/sync

### DIFF
--- a/lua/launcher_config.lua
+++ b/lua/launcher_config.lua
@@ -86,8 +86,8 @@ local commands = {
 				["s立即屏保3"] = [[osascript -e 'tell application "System Events" to start current screen saver']],
 				["l系统明暗模式4"] = [[osascript -e \
                 'tell application "System Events" to tell appearance preferences to set dark mode to not dark mode']],
-				["b部署Fcitx5"] = "/Library/Input Methods/Fcitx5.app/Contents/bin/fcitx5-curl /config/addon/rime/deploy -X POST -d '{}'",
-				["f同步Fcitx6"] = "/Library/Input Methods/Fcitx5.app/Contents/bin/fcitx5-curl /config/addon/rime/sync -X POST -d '{}'",
+				["b部署Fcitx5"] = "/Library/Input Methods/Fcitx5.app/Contents/bin/fcitx5-curl /config/addon/rime/deploy -X POST -d '{}' &",
+				["f同步Fcitx6"] = "/Library/Input Methods/Fcitx5.app/Contents/bin/fcitx5-curl /config/addon/rime/sync -X POST -d '{}' &",
 				["h隐藏桌面图标7"] = "defaults write com.apple.finder CreateDesktop false && killall Finder",
 				["i显示桌面图标8"] = "defaults write com.apple.finder CreateDesktop true && killall Finder",
 				["x立即熄屏9"] = "pmset displaysleepnow",


### PR DESCRIPTION
首先感谢适配小企鹅 macOS 版！

#60 提到的部署/同步小企鹅导致死机问题我可以复现。
* 小企鹅的工作方式是：UI 线程发送按键给 fcitx 线程，等它处理完返回结果。
* 此用例中，fcitx 线程调用 lua，lua 调用命令行部署；但是这一步返回不了，因为小企鹅的 http server 线程收到请求后也要调用 fcitx 线程部署，可 fcitx 线程此时正在等命令行返回，就死锁了。

经测试，添加 & 将部署命令移至后台执行可以解决。